### PR TITLE
Error handling for Integer and Decimal values during configuration

### DIFF
--- a/Common/Helper/ModalHelper.cs
+++ b/Common/Helper/ModalHelper.cs
@@ -4,11 +4,6 @@ public static class ModalHelper
 {
     public static string GetModalName(ulong userId, string modalName, string[] additionalInfo)
     {
-        return GetModalName(userId.ToString(), modalName, additionalInfo);
-    }
-
-    public static string GetModalName(string userId, string modalName, string[] additionalInfo)
-    {
         return $"{userId}_{modalName}_{string.Join("_", additionalInfo)}";
     }
 

--- a/Main/Events/ClientOnComponentInteractionCreatedEvent.cs
+++ b/Main/Events/ClientOnComponentInteractionCreatedEvent.cs
@@ -33,6 +33,9 @@ internal static class ClientOnComponentInteractionCreatedEvent
             case "configCategories":
                 await new ConfigurationCategorySelectedHandler(sender, e).RunAsync();
                 break;
+            case "configOptions" when additionalInfo.Length == 1:
+                await new ConfigurationOptionSelectedHandler(sender, e, additionalInfo[0]).RunAsync();
+                break;
             case "configOptions":
                 await new ConfigurationOptionSelectedHandler(sender, e).RunAsync();
                 break;

--- a/Main/Handler/ConfigurationOptionSelectedHandler.cs
+++ b/Main/Handler/ConfigurationOptionSelectedHandler.cs
@@ -12,14 +12,28 @@ namespace Main.Handler;
 
 internal sealed class ConfigurationOptionSelectedHandler : InteractionHandler
 {
+    private readonly string? _optionId;
+
     public ConfigurationOptionSelectedHandler(DiscordClient sender, ComponentInteractionCreateEventArgs e) :
         base(sender, e)
     {
     }
 
+    public ConfigurationOptionSelectedHandler(DiscordClient sender, ComponentInteractionCreateEventArgs e,
+        string optionId) :
+        this(sender, e)
+    {
+        _optionId = optionId;
+    }
+
     public override async Task RunAsync()
     {
-        var optionId = Convert.ToInt32(EventArgs.Values[0]);
+        // try to get from values (select menu, see ConfigurationCategorySelectedHandler)
+        // fallback to optionId (button, see ConfigurationOptionValueGivenHandler)
+        var optionIdString = EventArgs.Values.FirstOrDefault() ?? _optionId
+            ?? throw new ArgumentNullException(nameof(_optionId), "both value sources are null.");
+
+        var optionId = Convert.ToInt32(optionIdString);
         var option = ConfigOptions.Instance.Get(optionId);
         var optionDetailsEmbed = GetOptionDetailsEmbed(option);
 


### PR DESCRIPTION
Modals would previously show a generic error. The modal now closes and shows a more specific error, with an option to reopen the modal (see video in #16 comments).