### PR TITLE
Fix: Cannot change only description of menu

### DIFF
--- a/Main/Handler/SelfAssignMenuRenameHandler.cs
+++ b/Main/Handler/SelfAssignMenuRenameHandler.cs
@@ -34,11 +34,12 @@ internal sealed class SelfAssignMenuRenameHandler : ModalHandler
 
         var title = EventArgs.Values["title"] ?? string.Empty;
 
-        if (await context.SelfAssignMenus.AnyAsync(x => x.GuildId == menu.GuildId && x.Title.Equals(title)))
+        if (await context.SelfAssignMenus.AnyAsync(x =>
+                x.GuildId == menu.GuildId && x.Title.Equals(title) && x.Id != menu.Id))
         {
             await EventArgs.Interaction.CreateResponseAsync(InteractionResponseType.ChannelMessageWithSource,
                 new DiscordInteractionResponseBuilder()
-                    .AddErrorEmbed("A Self Assign Menu with that title already exists.").AsEphemeral());
+                    .AddErrorEmbed($"A Self Assign Menu with that title ({title}) already exists.").AsEphemeral());
             return;
         }
 


### PR DESCRIPTION
Bot would only check if target name already exists for the guild. It now checks whether it exists for the guild and whether it's a different entry by checking the PK.